### PR TITLE
feat: Add initial mobile navigation

### DIFF
--- a/assets/images/menu.svg
+++ b/assets/images/menu.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
+  <path d="M0 0v1h8v-1h-8zm0 2.97v1h8v-1h-8zm0 3v1h8v-1h-8z" transform="translate(0 1)" />
+</svg>

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -30,8 +30,8 @@ $shadow: 0px 5px 20px rgba(0, 0, 0, 0.1);
 
 // ==================
 // break-points
-$huge: 1440;
-$large: 1170;
+$huge: 1200;
+$large: 992;
 $medium: 768;
 $small: 600;
 

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="header">
     <v-container class="nav-bar" fluid>
-      <v-row>
-        <v-col v-for="(button, i) in leftButtons" :key="i - 1">
+      <v-row class="nav-row" v-if="fullView">
+        <v-col v-for="button in leftRoutes" :key="button.key">
           <v-btn
-            class="nav-button black--text"
+            class="nav-item black--text"
             color="transparent"
             depressed
             :to="button.path"
@@ -14,7 +14,7 @@
         </v-col>
         <v-col cols="4">
           <v-btn
-            class="nav-button black--text title-button"
+            class="nav-item black--text title-item"
             color="transparent"
             depressed
             to="/"
@@ -22,9 +22,9 @@
             >City Budget Tracker</v-btn
           >
         </v-col>
-        <v-col v-for="(button, i) in rightButtons" :key="i + 2">
+        <v-col v-for="button in rightRoutes" :key="button.key">
           <v-btn
-            class="nav-button black--text"
+            class="nav-item black--text"
             color="transparent"
             depressed
             :to="button.path"
@@ -33,36 +33,103 @@
           >
         </v-col>
       </v-row>
+      <v-row class="nav-row" v-else>
+        <v-col align="left">
+          <NuxtLink
+            class="nav-item black--text title-item"
+            color="transparent"
+            depressed
+            to="/"
+            nuxt
+            >City Budget Tracker</NuxtLink
+          >
+        </v-col>
+        <v-col class="nav-icon-col no-grow">
+          <img src="../assets/images/menu.svg"
+            alt="menu icon"
+            class="nav-icon"
+            @click="showNavDrawer = true"
+            >
+        </v-col>
+      </v-row>
     </v-container>
+    <v-navigation-drawer
+      v-model="showNavDrawer"
+      class="nav-drawer"
+      absolute
+      right
+      temporary
+    >
+      <v-list>
+        <v-list-item
+          v-for="route in routes"
+          :key="route.key"
+          link
+        >
+          <v-list-item-content>
+            <NuxtLink :to="route.path" class="nav-item"> 
+              {{ route.title }}
+            </NuxtLink>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-navigation-drawer>
   </div>
 </template>
 
 <script>
 export default {
-  computed: {
-    leftButtons() {
-      return [
+  data() {
+    return {
+      fullView: true,
+      showNavDrawer: false,
+      routes: [
         {
+          key: "see-budget",
           path: "/see-budget",
           title: "See Budget"
         },
         {
+          key: "balance-budget",
           path: "/balance-budget",
           title: "Balance Budget"
-        }
-      ];
-    },
-    rightButtons() {
-      return [
+        },
         {
+          key: "about",
           path: "/about",
           title: "About Us"
         },
         {
+          key: "take-action",
           path: "/take-action",
           title: "Take Action"
         }
-      ];
+      ]
+    }
+  },
+  created() {
+    this.onResize();
+    window.addEventListener('resize', this.onResize);
+  },
+  methods: {
+    onResize() {
+      this.fullView = window.innerWidth > 1200;
+      this.showNavDrawer = this.showNavDrawer && !this.fullView;
+    }
+  },
+  computed: {
+    routeCount() {
+      return this.routes.length;
+    },
+    leftRoutes() {
+      return this.routes.slice(
+        0, Math.ceil(this.routeCount / 2)
+      );
+    },
+    rightRoutes() {
+      return this.routes.slice(
+        Math.ceil(this.routeCount / 2), this.routeCount
+      );
     }
   }
 };
@@ -83,21 +150,47 @@ export default {
   max-width: 1200px;
 }
 
-.nav-button {
+.nav-row {
+  margin: 0 24px;
+}
+
+.nav-icon-col {
+  text-align: right;
+  align-self: center;
+}
+
+.nav-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.nav-drawer {
+  background-color: $light-turquoise;
+}
+
+.nav-item {
   @include p();
+  color: initial;
+  text-decoration: none;
+  letter-spacing: 0.09em;
+  text-indent: 0.09em;
 }
 
 // Have to be super specific to override Vuetify styles
-.header .nav-bar .nav-button.title-button {
-  @include h1();
+.header .nav-bar .nav-item.title-item {
+  @include h3();
   text-transform: none;
+
+  @include largerThan(1200) {
+    @include h1();
+  }
 }
 
-.header .nav-bar .nav-button.v-btn--active::before {
+.header .nav-bar .nav-item.v-btn--active::before {
   opacity: 0;
 }
 
-.header .nav-bar .nav-button.v-btn--active:hover::before {
+.header .nav-bar .nav-item.v-btn--active:hover::before {
   opacity: 0.08;
 }
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,7 +3,7 @@ export default {
   ** Nuxt rendering mode
   ** See https://nuxtjs.org/api/configuration-mode
   */
-  mode: 'universal',
+  mode: 'spa',
   /*
   ** Nuxt target
   ** See https://nuxtjs.org/api/configuration-target


### PR DESCRIPTION
Note that sheet height for the nav drawer is borked and confined to only
the header height, will need to refactor the header's absolute positioning
in order to fix. Homepage background image should be the thing that's absolute.

| mobile | medium | large |
| --- | --- | ---
| <img width="411" alt="Screen Shot 2020-09-09 at 1 00 30 AM" src="https://user-images.githubusercontent.com/12961270/92571543-21f4c080-f238-11ea-879f-7a145f121f96.png"> | <img width="810" alt="Screen Shot 2020-09-09 at 1 01 03 AM" src="https://user-images.githubusercontent.com/12961270/92571574-24571a80-f238-11ea-9ea7-125f434dcd7d.png"> | <img width="1246" alt="Screen Shot 2020-09-09 at 1 01 25 AM" src="https://user-images.githubusercontent.com/12961270/92571580-2620de00-f238-11ea-9465-39b8e66dfea8.png"> |


