### PR TITLE
feat: Add app-wide state for city and year choice

### DIFF
--- a/components/CityFilter.vue
+++ b/components/CityFilter.vue
@@ -6,16 +6,7 @@
     <p class="city-filter__subtitle">
       You pay taxes. We do too. Where does that money go?
     </p>
-    <div class="city-filter__select">
-      <label for="city-select">Select your city</label>
-      <v-select id="city-select"
-        background-color="#fff"
-        value="san_francisco"
-        :items="items"
-        light
-        outlined>
-      </v-select>
-    </div>
+    <CitySelect class="city-filter__select" />
     <v-btn
       class="city-filter__button"
       to="/balance-budget"
@@ -27,19 +18,14 @@
 </template>
 
 <script lang="ts">
-export default {
-  data() {
-    return {
-      items: [
-        {
-          text: 'San Francisco',
-          value: 'san_francisco',
-          disabled: false,
-        },
-      ],
-    };
+import Vue from 'vue';
+import CitySelect from '@/components/CitySelect';
+
+export default Vue.extend({
+  components: {
+    CitySelect,
   },
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/components/CitySelect.vue
+++ b/components/CitySelect.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <label for="city-select">Select your city</label>
+    <v-select id="city-select"
+      background-color="white"
+      color="black"
+      v-model="selectedCity"
+      :items="cities"
+      light
+      outlined
+      dense>
+    </v-select>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {
+    selectedCity: {
+      get() { return this.$store.state.city; },
+      set(value) { this.$store.commit('updateCity', value); },
+    }    
+  },
+  data() {
+    return {
+      cities: [
+        {
+          text: 'San Francisco',
+          value: 'san_francisco',
+          disabled: false,
+        },
+        {
+          text: 'Oakland',
+          value: 'oakland',
+          disabled: false,
+        },
+      ],
+    };
+  },
+};
+</script>
+<style scoped lang="scss">
+  label {
+    @include font-size(12);
+  }
+</style>  

--- a/components/FiscalYearSelect.vue
+++ b/components/FiscalYearSelect.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <label for="fiscal-year-select">Fiscal Year</label>
+    <v-select id="fiscal-year-select"
+      background-color="white"
+      color="black"
+      v-model="selectedFiscalYear"
+      :items="years"
+      light
+      outlined
+      dense>
+    </v-select>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {
+    selectedFiscalYear: {
+      get() { return this.$store.state.year; },
+      set(value) { this.$store.commit('updateFiscalYear', value); },
+    }    
+  },
+  data() {
+    return {
+      years: [
+        {
+          text: '2020-2021',
+          value: '2020',
+          disabled: false,
+        },
+        {
+          text: '2019-2020',
+          value: '2019',
+          disabled: false,
+        },
+      ],
+    };
+  },
+};
+</script>
+<style scoped lang="scss">
+  label {
+    @include font-size(12);
+  }
+</style>  

--- a/pages/balance-budget.vue
+++ b/pages/balance-budget.vue
@@ -10,26 +10,10 @@
         </v-row>
         <v-row class="Balance-Budget-Header-Dropdown-Container">
           <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
-            <div class="Dropdown-Title">Select Your City</div>
-            <v-select
-              :items="cities"
-              placeholder="San Francisco"
-              background-color="white"
-              outlined
-              dense
-              color="black"
-            ></v-select>
+            <CitySelect />
           </v-col>
           <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
-            <div class="Dropdown-Title">Fiscal Year</div>
-            <v-select
-              :items="years"
-              placeholder="2020-2021"
-              background-color="white"
-              outlined
-              dense
-              color="black"
-            ></v-select>
+            <FiscalYearSelect />
           </v-col>
         </v-row>
         <v-row class="mb-10">
@@ -278,12 +262,16 @@
 
 <script lang="ts">
 import Vue from "vue";
-import Header from "@/components/Header.vue";
-import Footer from "@/components/Footer.vue";
-import DepartmentsWalkthrough from "@/components/DepartmentsWalkthrough.vue";
+import CitySelect from "@/components/CitySelect";
+import FiscalYearSelect from "@/components/FiscalYearSelect";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import DepartmentsWalkthrough from "@/components/DepartmentsWalkthrough";
 
 export default Vue.extend({
   components: {
+    CitySelect,
+    FiscalYearSelect,
     Header,
     Footer,
     DepartmentsWalkthrough

--- a/pages/see-budget.vue
+++ b/pages/see-budget.vue
@@ -18,26 +18,10 @@
 
           <v-row class="content-row body-row">
             <v-col>
-              <label for="city-select">
-                Select your city
-              </label>
-              <v-select id="city-select"
-                value="san_francisco"
-                :items="cities"
-                v-model="selected_city"
-                background-color=white outlined dense light>
-              </v-select>
+              <CitySelect />
             </v-col>
             <v-col>
-              <label for="fiscal-year-select">
-                Fiscal Year
-              </label>
-              <v-select id="fiscal-year-select"
-                value="2020"
-                :items="years"
-                v-model="selected_start_year"
-                background-color=white outlined dense light>
-              </v-select>
+              <FiscalYearSelect />
             </v-col>
           </v-row>
 
@@ -93,6 +77,8 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import CitySelect from '@/components/CitySelect';
+import FiscalYearSelect from '@/components/FiscalYearSelect';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { D3LineChart } from 'vue-d3-charts';
@@ -100,6 +86,8 @@ import ORG_BUDGET_BY_YEAR from '../assets/data/sf_yearly_budgets_by_org.json';
 
 export default Vue.extend({
   components: {
+    CitySelect,
+    FiscalYearSelect,
     D3LineChart,
     Header,
     Footer,
@@ -110,32 +98,6 @@ export default Vue.extend({
   data() {
     return {
       isMounted: false,
-      selected_city: 'san_francisco',
-      selected_start_year: '2020',
-      cities: [
-        {
-          text: 'San Francisco',
-          value: 'san_francisco',
-          disabled: false,
-        },
-        {
-          text: 'Oakland',
-          value: 'oakland',
-          disabled: false,
-        },
-      ],
-      years: [
-        {
-          text: '2019-2020',
-          value: '2019',
-          disabled: false,
-        },
-        {
-          text: '2020-2021',
-          value: '2020',
-          disabled: false,
-        },
-      ],
       orgBudgetByYear: ORG_BUDGET_BY_YEAR,
       orgBudgetChartConfig: {
         values: Object.keys(ORG_BUDGET_BY_YEAR[0]),

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,13 @@
+export const state = () => ({
+  city: 'san_francisco',
+  year: '2020',
+})
+
+export const mutations = {
+  updateCity(state, city) {
+    state.city = city;
+  },
+  updateFiscalYear(state, year) {
+    state.year = year;
+  }
+}


### PR DESCRIPTION
Using Vuex (already included in Nuxt) will allow us to track app-wide state
for city and fiscal year choice and prepopulate across selectors on different
pages, while still allowing users to change them via any of those selectors.

Also refactors selectors into shared components.

Issue #30 