### PR TITLE
refactor: Move budget amounts to shared Vuex state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
     'import/no-unresolved': 0,
     'import/extensions': 0,
     'no-unused-vars': [1, { argsIgnorePattern: '^_' }],
+    // `st` used for Vuex state mutations
+    'no-param-reassign': [1, { ignorePropertyModificationsFor: ['st'] }],
   },
   settings: {
     'import/resolver': {

--- a/components/DepartmentsWalkthrough.vue
+++ b/components/DepartmentsWalkthrough.vue
@@ -25,11 +25,12 @@
           <v-col>
             <v-row>
               <div class="Category-Slider">
-                <div class="Slider-Amount">${{ department.storedValue }} mil</div>
+                <div class="Slider-Amount">${{ amounts[department.name] }} mil</div>
                 <v-row justify="center">
                   <v-slider
-                    v-bind:max="department.sliderMax"
-                    v-model="department.storedValue"
+                    v-bind:max="totalAmount"
+                    :value="amounts[department.name]"
+                    @change="value => { updateAmount(department.name, value) }"
                     min="0"
                     vertical
                     track-color="#B6DADA"
@@ -49,7 +50,7 @@
             v-bind:key="button.name"
             class="carousel-controls__button"
             v-bind:class="button.class"
-            v-bind:disabled="department.storedValue == 0"
+            v-bind:disabled="amounts[department.name] == 0"
             v-bind:outlined="button.outlined"
             rounded
             depressed
@@ -66,140 +67,127 @@
 </template>
 
 <script>
-import Vue from "vue";
-
 export default {
+  computed: {
+    totalAmount() { return this.$store.getters['budget/getTotalAmount']; },
+    amounts() {
+      return this.$store.getters['budget/getAmounts'];
+    },
+    buttonsShow() {
+      return this.buttons.filter((button) => button.render);
+    },
+  },
   data() {
     return {
       index: 0,
       departments: [
         {
-          name: "community-health",
-          header: "Community Health",
+          name: 'health',
+          header: 'Community Health',
           content:
-            "The mission of the Department of Public Health is to protect and promote the health of all San Franciscans through the following divisions:<ul><li>San Francisco Health Network, which includes the Zuckerberg San Francisco General Hospital, Laguna Honda Hospital, ambulatory care, and transitions that oversee client flow throughout the system of care.</li><li>Population Health Division, which addresses public health concerns, including consumer safety, health promotion and disease prevention, and the monitoring of threats to the public’s health.</li></ul><br>Funds:<ul><li>Expand behavioral services for vulnerable residents, many of whom are experiencing homelessness</li><li>Provide department-wide workplace equity training and education</li><li>Implement a new electronic health record that supports clinical operations and revenue collections</li><li>Promote health education, physical activity, and healthy eating in communities with high rates of sugary drink consumption, diabetes, obesity, and heart disease</li><li>Increase staff at the hospitals and budget for other medical supplies including test kits for population health and prevention</li></ul>.",
-          budget: "$2,422 mil",
-          display: "inherit",
-          sliderMax: 16452,
-          storedValue: 0
+            'The mission of the Department of Public Health is to protect and promote the health of all San Franciscans through the following divisions:<ul><li>San Francisco Health Network, which includes the Zuckerberg San Francisco General Hospital, Laguna Honda Hospital, ambulatory care, and transitions that oversee client flow throughout the system of care.</li><li>Population Health Division, which addresses public health concerns, including consumer safety, health promotion and disease prevention, and the monitoring of threats to the public’s health.</li></ul><br>Funds:<ul><li>Expand behavioral services for vulnerable residents, many of whom are experiencing homelessness</li><li>Provide department-wide workplace equity training and education</li><li>Implement a new electronic health record that supports clinical operations and revenue collections</li><li>Promote health education, physical activity, and healthy eating in communities with high rates of sugary drink consumption, diabetes, obesity, and heart disease</li><li>Increase staff at the hospitals and budget for other medical supplies including test kits for population health and prevention</li></ul>.',
+          budget: '$2,422 mil',
+          display: 'inherit',
         },
         {
-          name: "culture-recreation",
-          header: "Culture & Recreation",
+          name: 'culture',
+          header: 'Culture & Recreation',
           content:
-            "San Francisco’s recreational, cultural, and educational resources drive our quality of life and underlie our shared experience as a city. Keeping these institutions in a state of good repair is a priority. Departments include:<ul><li>Academy of Sciences</li><li>Arts Commission</li><li>Asian Art Museum</li><li>Fine Arts Museum (de Young and Legion of Honor Museums)</li><li>Law Library</li><li>Public Library (Main Library at Civic Center and 27 branch libraries)</li><li>Recreation & Parks (200+ parks, playgrounds, and open spaces)</li><li>War Memorial (War Memorial Opera House, Veterans Building, Davies Symphony Hall, and adjacent grounds)</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Source: City of San Francisco Budget Book",
-          budget: "$489 mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
+            'San Francisco’s recreational, cultural, and educational resources drive our quality of life and underlie our shared experience as a city. Keeping these institutions in a state of good repair is a priority. Departments include:<ul><li>Academy of Sciences</li><li>Arts Commission</li><li>Asian Art Museum</li><li>Fine Arts Museum (de Young and Legion of Honor Museums)</li><li>Law Library</li><li>Public Library (Main Library at Civic Center and 27 branch libraries)</li><li>Recreation & Parks (200+ parks, playgrounds, and open spaces)</li><li>War Memorial (War Memorial Opera House, Veterans Building, Davies Symphony Hall, and adjacent grounds)</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Source: City of San Francisco Budget Book',
+          budget: '$489 mil',
+          display: 'none',
         },
         {
-          name: "general-admin-finance",
-          header: "General Admin & Finance",
+          name: 'admin',
+          header: 'General Admin & Finance',
           content:
-            "A departmental designation for expenditures and revenues that are citywide in nature. Examples are voter mandated General Fund support for transit, libraries, and other baselines, the General Fund portion of retiree health premiums, nonprofit cost of doing business increases, required reserve deposits and debt service. Departments include:<ul><li>Assessor/Recorder</li><li>Board of Supervisors</li><li>City Attorney</li><li>City Planning</li><li>Civil Service Commission</li><li>Controller</li><li>Elections</li><li>Ethics Commission</li><li>General Services Agency - City Administrator (aka Administrative Services)</li><li>General Services Agency - Technology</li><li>Health Service System</li><li>Human Resources</li><li>Mayor</li><li>Medical Examiner (Program under General Services Agency - City Admin)</li><li>Real Estate (Program under General Services Agency - City Admin)</li><li>Retirement System</li><li>Treasurer/Tax Collector</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Funds:<ul><li>Modernize the city’s property assessment and tax systems</li><li>Pay salaries</li><li>Prepares for future elections and increased voter turnout by increasing temporary staffing and administering the vote-by-mail program</li></ul>",
-          budget: "$x mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
+            'A departmental designation for expenditures and revenues that are citywide in nature. Examples are voter mandated General Fund support for transit, libraries, and other baselines, the General Fund portion of retiree health premiums, nonprofit cost of doing business increases, required reserve deposits and debt service. Departments include:<ul><li>Assessor/Recorder</li><li>Board of Supervisors</li><li>City Attorney</li><li>City Planning</li><li>Civil Service Commission</li><li>Controller</li><li>Elections</li><li>Ethics Commission</li><li>General Services Agency - City Administrator (aka Administrative Services)</li><li>General Services Agency - Technology</li><li>Health Service System</li><li>Human Resources</li><li>Mayor</li><li>Medical Examiner (Program under General Services Agency - City Admin)</li><li>Real Estate (Program under General Services Agency - City Admin)</li><li>Retirement System</li><li>Treasurer/Tax Collector</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Funds:<ul><li>Modernize the city’s property assessment and tax systems</li><li>Pay salaries</li><li>Prepares for future elections and increased voter turnout by increasing temporary staffing and administering the vote-by-mail program</li></ul>',
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "general-city-responsibilities",
-          header: "General City Responsibilities",
-          content: "",
-          budget: "$x mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
+          name: 'city',
+          header: 'General City Responsibilities',
+          content: '',
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "human-welfare-neighborhood-development",
-          header: "Human Welfare & Neighborhood Development",
-          content: "",
-          budget: "$x mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
+          name: 'welfare',
+          header: 'Human Welfare & Neighborhood Development',
+          content: '',
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "public-protection",
-          header: "Public Protection",
-          content: "",
-          budget: "$x mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
+          name: 'protection',
+          header: 'Public Protection',
+          content: '',
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "public-works-transportation-commerce",
-          header: "Public Works, Transportation, & Commerce",
-          content: "",
-          budget: "$x mil",
-          display: "none",
-          sliderMax: 16452,
-          storedValue: 0
-        }
+          name: 'transport',
+          header: 'Public Works, Transportation, & Commerce',
+          content: '',
+          budget: '$x mil',
+          display: 'none',
+        },
       ],
       buttons: [
         {
-          name: "prev",
+          name: 'prev',
           outlined: true,
-          method: "previous",
-          class: "",
-          render: false
+          method: 'previous',
+          class: '',
+          render: false,
         },
         {
-          name: "next",
+          name: 'next',
           outlined: false,
-          method: "next",
-          class: "white--text",
-          render: true
+          method: 'next',
+          class: 'white--text',
+          render: true,
         },
         {
-          name: "finish",
+          name: 'finish',
           outlined: false,
-          method: "next",
-          class: "white--text",
-          render: false
-        }
-      ]
+          method: 'next',
+          class: 'white--text',
+          render: false,
+        },
+      ],
     };
-  },
-  computed: {
-    buttonsShow: function() {
-      return this.buttons.filter(function(button) {
-        return button.render;
-      });
-    }
   },
   methods: {
     expand() {
-      const Text = document.querySelector(".Category-Content-Text");
-      Text.style.overflow = "inherit";
-      var Btn = document.getElementById("btn");
+      const Text = document.querySelector('.Category-Content-Text');
+      Text.style.overflow = 'inherit';
+      const Btn = document.getElementById('btn');
       Btn.remove();
     },
     navigate(button) {
       this.buttons[0].render = true;
-      if (button == "next") {
-        this.departments[this.index].display = "none";
+      if (button === 'next') {
+        this.departments[this.index].display = 'none';
         this.index += 1;
-        this.departments[this.index].display = "inherit";
-        this.departments[this.index].sliderMax =
-          this.departments[this.index - 1].sliderMax - this.departments[this.index - 1].storedValue;
-      } else if (button == "prev") {
-        this.departments[this.index].display = "none";
+        this.departments[this.index].display = 'inherit';
+      } else if (button === 'prev') {
+        this.departments[this.index].display = 'none';
         this.index -= 1;
-        this.departments[this.index].display = "inherit";
+        this.departments[this.index].display = 'inherit';
       }
-      if (this.index == 0) {
+      if (this.index === 0) {
         this.buttons[0].render = false;
-      } else if (this.index == 6) {
+      } else if (this.index === 6) {
         this.buttons[1].render = false;
         this.buttons[2].render = true;
       }
-    }
-  }
+    },
+    updateAmount(department, value) {
+      this.$store.commit('budget/updateAmounts', { [department]: value });
+    },
+  },
 };
 </script>
 

--- a/pages/balance-budget.vue
+++ b/pages/balance-budget.vue
@@ -1,246 +1,235 @@
 <template>
-  <v-app style="background: #f1f8f8">
-    <v-container fluid class="HomePage-Container" fill-height>
-      <div class="origin">
-        <v-row>
-          <Header />
-        </v-row>
+  <v-app>
+    <v-row>
+      <Header />
+    </v-row>
 
-        <v-row justify="center">
-          <h2 class="Section-Title">Balance My City's Budget</h2>
-        </v-row>
+    <v-container fluid class="no-padding" fill-height>
 
-        <v-row class="Balance-Budget-Header-Dropdown-Container">
-          <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
-            <CitySelect />
-          </v-col>
-          <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
-            <FiscalYearSelect />
-          </v-col>
-        </v-row>
+      <v-row justify="center">
+        <h2 class="Section-Title">Balance My City's Budget</h2>
+      </v-row>
 
-        <v-row class="mb-10">
-          <v-spacer cols=2 />
-          <v-col cols=4>
-            <v-row><div class="Subsection-Title">Revenue</div></v-row>
-            <v-row><div class="Subsection-Subtitle">(in millions)</div></v-row>
-            <v-row class="mb-5">
-              <div class="Subsection-Amount">${{totalExpenses}} mil</div>
-            </v-row>
-            <v-row><div class="Subsection-Title">Expenses</div></v-row>
-            <v-row><div class="Subsection-Subtitle">(in millions)</div></v-row>
-            <v-row><div class="Subsection-Body">
-              There are 7 categories that make up San Francisco's budget.
-              Use the levers to adjust and balance the spending for each category,
-              then compare to the actual budget.
-            </div></v-row>
-            <v-row class="mb-0" v-if="exceedsLimit">
-              <div class="Slider-Hint">Note: Total expenses allocated exceeds revenue.</div>
-            </v-row>
-          </v-col>
-          <v-col cols=6>
-              <D3PieChart
-                v-if="isMounted"
-                :config="budgetPieChartConfig"
-                :datum="budgetPieChartData" />
-          </v-col>
-        </v-row>
+      <v-row class="Balance-Budget-Header-Dropdown-Container">
+        <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
+          <CitySelect />
+        </v-col>
+        <v-col class="Balance-Budget-Header-Dropdown" xs="3" md="3">
+          <FiscalYearSelect />
+        </v-col>
+      </v-row>
 
-        <v-row justify="center">
-          <v-spacer />
-          <v-col cols=2>
-            <div class="color Health-Color" />
-            <div class="Slider-Title">Community Health
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-col cols=2>
-            <div class="color Culture-Color" />
-            <div class="Slider-Title">Culture & Recreation
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-col cols=2>
-            <div class="color Admin-Color" />
-            <div class="Slider-Title">General Admin & Finance
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-col cols=2>
-            <div class="color City-Color" />
-            <div class="Slider-Title">General City Responsibilities
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template><span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-spacer />
-        </v-row>
+      <v-row class="mb-10">
+        <v-spacer cols=2 />
+        <v-col cols=4>
+          <v-row><div class="Subsection-Title">Revenue</div></v-row>
+          <v-row><div class="Subsection-Subtitle">(in millions)</div></v-row>
+          <v-row class="mb-5">
+            <div class="Subsection-Amount">${{totalExpenses}} mil</div>
+          </v-row>
+          <v-row><div class="Subsection-Title">Expenses</div></v-row>
+          <v-row><div class="Subsection-Subtitle">(in millions)</div></v-row>
+          <v-row><div class="Subsection-Body">
+            There are 7 categories that make up San Francisco's budget.
+            Use the levers to adjust and balance the spending for each category,
+            then compare to the actual budget.
+          </div></v-row>
+          <v-row class="mb-0" v-if="exceedsLimit">
+            <div class="Slider-Hint">Note: Total expenses allocated exceeds revenue.</div>
+          </v-row>
+        </v-col>
+        <v-col cols=6>
+            <D3PieChart
+              v-if="isMounted && amounts"
+              :config="budgetPieChartConfig"
+              :datum="budgetPieChartData" />
+        </v-col>
+      </v-row>
 
-        <v-row>
-          <v-spacer />
-          <v-col cols=2><div class="Slider-Amount">${{healthValue}} mil</div></v-col>
-          <v-col cols=2><div class="Slider-Amount">${{cultureValue}} mil</div></v-col>
-          <v-col cols=2><div class="Slider-Amount">${{adminValue}} mil</div></v-col>
-          <v-col cols=2><div class="Slider-Amount">${{cityValue}} mil</div></v-col>
-          <v-spacer />
-        </v-row>
+      <v-row justify="center">
+        <v-spacer />
+        <v-col cols=2>
+          <div class="color Health-Color" />
+          <div class="Slider-Title">Community Health
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-col cols=2>
+          <div class="color Culture-Color" />
+          <div class="Slider-Title">Culture & Recreation
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-col cols=2>
+          <div class="color Admin-Color" />
+          <div class="Slider-Title">General Admin & Finance
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-col cols=2>
+          <div class="color City-Color" />
+          <div class="Slider-Title">General City Responsibilities
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template><span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row>
-          <v-spacer />
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="healthValue" :max="sliderMax" :min="sliderMin"
-              @change="editPieChart('Community Health', healthValue, '#2A6465')"
-              :rules="revenueLimitRule" label=" "
-              track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="cultureValue" :max="sliderMax" :min="sliderMin"
-              @change="editPieChart('Culture & Recreation', cultureValue, '#EF896E')"
-              :rules="revenueLimitRule" label=" "
-              track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="adminValue" :max="sliderMax" :min="sliderMin"
-              @change="editPieChart('General Admin & Finance', adminValue, '#F5BD41')"
-              :rules="revenueLimitRule" label=" "
-              track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="cityValue" :max="sliderMax" :min="sliderMin"
-              @change="editPieChart('General City Responsibilities', cityValue, '#CAAA97')"
-              :rules="revenueLimitRule" label=" "
-              track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-spacer />
-        </v-row>
+      <v-row>
+        <v-spacer />
+        <v-col cols=2><div class="Slider-Amount">${{healthValue}} mil</div></v-col>
+        <v-col cols=2><div class="Slider-Amount">${{cultureValue}} mil</div></v-col>
+        <v-col cols=2><div class="Slider-Amount">${{adminValue}} mil</div></v-col>
+        <v-col cols=2><div class="Slider-Amount">${{cityValue}} mil</div></v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row justify="center">
-          <v-spacer />
-          <v-col cols=2>
-            <div class="color Welfare-Color" />
-            <div class="Slider-Title">
-              Human Welfare & Neighborhood Development
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-col cols=2>
-            <div class="color Protection-Color" /><div class="Slider-Title">
-              Public Protection
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-col cols=2>
-            <div class="color Transport-Color" /><div class="Slider-Title">
-              Public Works, Transportation & Commerce
-              <v-tooltip bottom>
-                <template v-slot:activator="{ on, attrs }">
-                  <span v-bind="attrs" v-on="on">(i)</span>
-                </template>
-                <span>Placeholder</span>
-              </v-tooltip>
-            </div>
-          </v-col>
-          <v-spacer />
-        </v-row>
+      <v-row>
+        <v-spacer />
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="healthValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="cultureValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="adminValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="cityValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row>
-          <v-spacer />
-          <v-col cols=2><div class="Slider-Amount">${{welfareValue}} mil</div></v-col>
-          <v-col cols=2><div class="Slider-Amount">${{protectionValue}} mil</div></v-col>
-          <v-col cols=2><div class="Slider-Amount">${{transportValue}} mil</div></v-col>
-          <v-spacer />
-        </v-row>
+      <v-row justify="center">
+        <v-spacer />
+        <v-col cols=2>
+          <div class="color Welfare-Color" />
+          <div class="Slider-Title">
+            Human Welfare & Neighborhood Development
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-col cols=2>
+          <div class="color Protection-Color" /><div class="Slider-Title">
+            Public Protection
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-col cols=2>
+          <div class="color Transport-Color" /><div class="Slider-Title">
+            Public Works, Transportation & Commerce
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <span v-bind="attrs" v-on="on">(i)</span>
+              </template>
+              <span>Placeholder</span>
+            </v-tooltip>
+          </div>
+        </v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row>
-          <v-spacer />
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="welfareValue" :max="sliderMax" :min="sliderMin"
-                        @change="editPieChart(
-                          'Human Welfare & Neighborhood Development',
-                          welfareValue,
-                          '#4DA54A'
-                        )"
-                        :rules="revenueLimitRule" label=" "
-                        track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="protectionValue" :max="sliderMax" :min="sliderMin"
-                        @change="editPieChart(
-                          'Public Protection',
-                          protectionValue,
-                          '#4296AD'
-                        )"
-                        :rules="revenueLimitRule" label=" "
-                        track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-col cols=2>
-            <v-row justify="center">
-              <v-slider v-model="transportValue" :max="sliderMax" :min="sliderMin"
-              @change="editPieChart(
-                'Public Works, Transportation & Commerce',
-                transportValue,
-                '#CF722A'
-              )"
-              :rules="revenueLimitRule" label=" "
-              track-color=#B6DADA color=#2A6465 vertical />
-            </v-row>
-          </v-col>
-          <v-spacer />
-        </v-row>
+      <v-row>
+        <v-spacer />
+        <v-col cols=2><div class="Slider-Amount">${{welfareValue}} mil</div></v-col>
+        <v-col cols=2><div class="Slider-Amount">${{protectionValue}} mil</div></v-col>
+        <v-col cols=2><div class="Slider-Amount">${{transportValue}} mil</div></v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row justify="center" class="my-10">
-          <v-spacer />
-          <v-col cols=2><v-btn rounded color=#2A6465 dark block>NEXT</v-btn></v-col>
-          <v-spacer />
-        </v-row>
+      <v-row>
+        <v-spacer />
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="welfareValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="protectionValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-col cols=2>
+          <v-row justify="center">
+            <v-slider v-model="transportValue" :max="sliderMax" :min="sliderMin"
+                      @change="refreshPieChartData"
+                      :rules="revenueLimitRule" label=" "
+                      track-color=#B6DADA color=#2A6465 vertical />
+          </v-row>
+        </v-col>
+        <v-spacer />
+      </v-row>
 
-        <v-row justify="center" class="my-10">
-          <v-spacer />
-        </v-row>
-      </div>
+      <v-row justify="center" class="my-10">
+        <v-spacer />
+        <v-col cols=2><v-btn rounded color=#2A6465 dark block>NEXT</v-btn></v-col>
+        <v-spacer />
+      </v-row>
+
+      <v-row justify="center" class="my-10">
+        <v-spacer />
+      </v-row>
       <DepartmentsWalkthrough />
-      <Footer />
     </v-container>
+    <v-row>
+      <Footer />
+    </v-row>
   </v-app>
 </template>
 
@@ -255,45 +244,7 @@ import FiscalYearSelect from '@/components/FiscalYearSelect';
 
 import DepartmentsWalkthrough from '@/components/DepartmentsWalkthrough';
 
-const totalExpenses = 1234.0;
-const startingExpense = totalExpenses / 7.0;
-const currentExpenses = [
-  {
-    name: 'Community Health',
-    total: startingExpense,
-    deptColor: '#2A6465',
-  },
-  {
-    name: 'Culture & Recreation',
-    total: startingExpense,
-    deptColor: '#EF896E',
-  },
-  {
-    name: 'General Admin & Finance',
-    total: startingExpense,
-    deptColor: '#F5BD41',
-  },
-  {
-    name: 'General City Responsibilities',
-    total: startingExpense,
-    deptColor: '#CAAA97',
-  },
-  {
-    name: 'Human Welfare & Neighborhood Development',
-    total: startingExpense,
-    deptColor: '#4DA54A',
-  },
-  {
-    name: 'Public Protection',
-    total: startingExpense,
-    deptColor: '#4296AD',
-  },
-  {
-    name: 'Public Works, Transportation & Commerce',
-    total: startingExpense,
-    deptColor: '#CF722A',
-  },
-];
+const TEMP_TOTAL_AMOUNT = 1234.0;
 
 export default Vue.extend({
   components: {
@@ -305,16 +256,98 @@ export default Vue.extend({
     DepartmentsWalkthrough,
   },
   mounted() {
+    this.initializeTotalAmount();
+    this.refreshPieChartData();
     this.isMounted = true;
-    this.exceedsLimit = false;
+  },
+  computed: {
+    exceedsLimit() { return this.$store.getters['budget/getExceedsLimit']; },
+    totalExpenses() { return this.$store.getters['budget/getTotalAmount']; },
+    amounts() {
+      return Object.values(this.$store.getters['budget/getAmounts'])
+        .some((amount) => amount > 0);
+    },
+    healthValue: {
+      get() { return this.$store.state.budget.amounts.health; },
+      set(v) { this.$store.commit('budget/updateAmounts', { health: v }); },
+    },
+    cultureValue: {
+      get() { return this.$store.state.budget.amounts.culture; },
+      set(v) { this.$store.commit('budget/updateAmounts', { culture: v }); },
+    },
+    adminValue: {
+      get() { return this.$store.state.budget.amounts.admin; },
+      set(v) { this.$store.commit('budget/updateAmounts', { admin: v }); },
+    },
+    cityValue: {
+      get() { return this.$store.state.budget.amounts.city; },
+      set(v) { this.$store.commit('budget/updateAmounts', { city: v }); },
+    },
+    welfareValue: {
+      get() { return this.$store.state.budget.amounts.welfare; },
+      set(v) { this.$store.commit('budget/updateAmounts', { welfare: v }); },
+    },
+    protectionValue: {
+      get() { return this.$store.state.budget.amounts.protection; },
+      set(v) { this.$store.commit('budget/updateAmounts', { protection: v }); },
+    },
+    transportValue: {
+      get() { return this.$store.state.budget.amounts.transport; },
+      set(v) { this.$store.commit('budget/updateAmounts', { transport: v }); },
+    },
+    budgetData() {
+      return [
+        {
+          key: 'health',
+          name: 'Community Health',
+          total: this.healthValue,
+          deptColor: '#2A6465',
+        },
+        {
+          key: 'culture',
+          name: 'Culture & Recreation',
+          total: this.cultureValue,
+          deptColor: '#EF896E',
+        },
+        {
+          key: 'admin',
+          name: 'General Admin & Finance',
+          total: this.adminValue,
+          deptColor: '#F5BD41',
+        },
+        {
+          key: 'city',
+          name: 'General City Responsibilities',
+          total: this.cityValue,
+          deptColor: '#CAAA97',
+        },
+        {
+          key: 'welfare',
+          name: 'Human Welfare & Neighborhood Development',
+          total: this.welfareValue,
+          deptColor: '#4DA54A',
+        },
+        {
+          key: 'protection',
+          name: 'Public Protection',
+          total: this.protectionValue,
+          deptColor: '#4296AD',
+        },
+        {
+          key: 'transport',
+          name: 'Public Works, Transportation & Commerce',
+          total: this.transportValue,
+          deptColor: '#CF722A',
+        },
+      ];
+    },
+    sliderMax() { return this.totalExpenses; },
+    sliderMin() { return 0; },
   },
   data() {
     return {
-      totalExpenses,
-      cities: ['San Francisco', 'Oakland'],
-      years: ['2015-2016', '2016-2017', '2017-2018', '2018-2019', '2019-2020', '2020-2021'],
       isMounted: false,
-      budgetPieChartData: currentExpenses,
+      budgetPieChartData: [],
       budgetPieChartConfig: {
         key: 'name',
         value: 'total',
@@ -322,35 +355,18 @@ export default Vue.extend({
         margin: { left: 100, right: 100 },
         transition: { duration: 100, ease: 'easeLinear' },
       },
-      sliderMax: totalExpenses,
-      sliderMin: 0,
-      healthValue: startingExpense,
-      cultureValue: startingExpense,
-      adminValue: startingExpense,
-      cityValue: startingExpense,
-      welfareValue: startingExpense,
-      protectionValue: startingExpense,
-      transportValue: startingExpense,
-      revenueLimitRule: [(v) => v + currentExpenses.slice(0, 6)
-        .reduce((sum, d) => sum + d.total, 0) <= totalExpenses],
+
+      revenueLimitRule: [], // (v) => v + currentExpenses.slice(0, 6)
+      // .reduce((sum, d) => sum + d.total, 0) <= totalExpenses],
     };
   },
   methods: {
-    editPieChart(dept, deptValue, color) {
-      currentExpenses[currentExpenses.findIndex((a) => a.name === dept)].total = deptValue;
-
-      const currentSumExpenses = currentExpenses.reduce((sum, d) => sum + d.total, 0);
-      if (currentSumExpenses > totalExpenses) {
-        this.exceedsLimit = true;
-      } else {
-        this.exceedsLimit = false;
-      }
-
-      this.budgetPieChartData.splice(
-        this.budgetPieChartData.findIndex(({ name }) => name === dept),
-        1,
-      );
-      this.budgetPieChartData.push({ name: dept, total: deptValue, deptColor: color });
+    initializeTotalAmount() {
+      this.$store.commit('budget/setTotalAmount', TEMP_TOTAL_AMOUNT);
+    },
+    refreshPieChartData() {
+      this.budgetPieChartData = this.budgetData
+        .filter((department) => department.total > 0);
     },
   },
 });

--- a/pages/see-budget.vue
+++ b/pages/see-budget.vue
@@ -4,7 +4,6 @@
       <Header />
     </v-row>
 
-
     <v-container fluid class="no-padding" fill-height>
 
       <v-row class="content-row body-row explore-budget">
@@ -37,7 +36,7 @@
         </v-container>
 
       </v-row>
-      
+
       <v-row class="content-row body-row">
         <h2 class="section-title">How is that money being spent?</h2>
       </v-row>
@@ -60,9 +59,9 @@
       <v-row class="content-row body-row white">
         <h2 class="section-title">Glossary</h2>
       </v-row>
-    
+
     </v-container>
-    
+
     <v-row>
       <Footer />
     </v-row>
@@ -101,10 +100,10 @@ export default Vue.extend({
           outputFormat: '%Y',
         },
         axis: {
-          yFormat: "$.2s",
+          yFormat: '$.2s',
         },
         color: { scheme: 'schemePaired' },
-      }
+      },
     };
   },
 });

--- a/store/budget.js
+++ b/store/budget.js
@@ -1,0 +1,35 @@
+export const state = () => ({
+  total_amount: 0,
+  amounts: {
+    health: 0,
+    culture: 0,
+    admin: 0,
+    city: 0,
+    welfare: 0,
+    protection: 0,
+    transport: 0,
+  },
+});
+
+export const getters = {
+  getTotalAmount(st) {
+    return st.total_amount;
+  },
+  getAmounts(st) {
+    return st.amounts;
+  },
+  getExceedsLimit(st) {
+    return Object.values(st.amounts)
+      .reduce((sum, el) => sum + el, 0) > st.total_amount;
+  },
+};
+
+export const mutations = {
+  updateAmounts(st, amountUpdates) {
+    st.amounts = { ...st.amounts, ...amountUpdates };
+  },
+
+  setTotalAmount(st, totalAmount) {
+    st.total_amount = totalAmount;
+  },
+};


### PR DESCRIPTION
This commit moves the user-selected budget amounts for the balance-budget page
into the Vuex `budget` module. This allows it to be shared across components,
in this case both the overview page as well as the carousel components.

This commit also does a small amount of refactoring to better support this
pattern, for example:
- filtering zero amounts out of the pie chart
- allowing carousel sliders to exceed the real budget (as the overview page
  already does)
- commenting out the individual slider validations for now (didn't have the
  brain power to make it work for now -- may require separate validation for
  each slider to make it easier)