### PR TITLE
feat: Move department descriptions into translation file by city

### DIFF
--- a/components/DepartmentsWalkthrough.vue
+++ b/components/DepartmentsWalkthrough.vue
@@ -87,10 +87,10 @@
 export default {
   computed: {
     totalAmount() {
-      return this.$store.getters["budget/getTotalAmount"];
+      return this.$store.getters['budget/getTotalAmount'];
     },
     amounts() {
-      return this.$store.getters["budget/getAmounts"];
+      return this.$store.getters['budget/getAmounts'];
     },
     buttonsShow() {
       return this.buttons.filter((button) => button.render);
@@ -101,78 +101,75 @@ export default {
       index: 0,
       departments: [
         {
-          name: "health",
-          header: "Community Health",
-          content:
-            "The mission of the Department of Public Health is to protect and promote the health of all San Franciscans through the following divisions:<ul><li>San Francisco Health Network, which includes the Zuckerberg San Francisco General Hospital, Laguna Honda Hospital, ambulatory care, and transitions that oversee client flow throughout the system of care.</li><li>Population Health Division, which addresses public health concerns, including consumer safety, health promotion and disease prevention, and the monitoring of threats to the public’s health.</li></ul><br>Funds:<ul><li>Expand behavioral services for vulnerable residents, many of whom are experiencing homelessness</li><li>Provide department-wide workplace equity training and education</li><li>Implement a new electronic health record that supports clinical operations and revenue collections</li><li>Promote health education, physical activity, and healthy eating in communities with high rates of sugary drink consumption, diabetes, obesity, and heart disease</li><li>Increase staff at the hospitals and budget for other medical supplies including test kits for population health and prevention</li></ul>.",
-          budget: "$2,422 mil",
-          display: "inherit",
+          name: 'health',
+          header: 'Community Health',
+          content: this.$t(`departments.health.longDescription.${this.$store.state.city}`),
+          budget: '$2,422 mil',
+          display: 'inherit',
         },
         {
-          name: "culture",
-          header: "Culture & Recreation",
-          content:
-            "San Francisco’s recreational, cultural, and educational resources drive our quality of life and underlie our shared experience as a city. Keeping these institutions in a state of good repair is a priority. Departments include:<ul><li>Academy of Sciences</li><li>Arts Commission</li><li>Asian Art Museum</li><li>Fine Arts Museum (de Young and Legion of Honor Museums)</li><li>Law Library</li><li>Public Library (Main Library at Civic Center and 27 branch libraries)</li><li>Recreation & Parks (200+ parks, playgrounds, and open spaces)</li><li>War Memorial (War Memorial Opera House, Veterans Building, Davies Symphony Hall, and adjacent grounds)</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Source: City of San Francisco Budget Book",
-          budget: "$489 mil",
-          display: "none",
+          name: 'culture',
+          header: 'Culture & Recreation',
+          content: this.$t(`departments.culture.longDescription.${this.$store.state.city}`),
+          budget: '$489 mil',
+          display: 'none',
         },
         {
-          name: "admin",
-          header: "General Admin & Finance",
-          content:
-            "A departmental designation for expenditures and revenues that are citywide in nature. Examples are voter mandated General Fund support for transit, libraries, and other baselines, the General Fund portion of retiree health premiums, nonprofit cost of doing business increases, required reserve deposits and debt service. Departments include:<ul><li>Assessor/Recorder</li><li>Board of Supervisors</li><li>City Attorney</li><li>City Planning</li><li>Civil Service Commission</li><li>Controller</li><li>Elections</li><li>Ethics Commission</li><li>General Services Agency - City Administrator (aka Administrative Services)</li><li>General Services Agency - Technology</li><li>Health Service System</li><li>Human Resources</li><li>Mayor</li><li>Medical Examiner (Program under General Services Agency - City Admin)</li><li>Real Estate (Program under General Services Agency - City Admin)</li><li>Retirement System</li><li>Treasurer/Tax Collector</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Funds:<ul><li>Modernize the city’s property assessment and tax systems</li><li>Pay salaries</li><li>Prepares for future elections and increased voter turnout by increasing temporary staffing and administering the vote-by-mail program</li></ul>",
-          budget: "$x mil",
-          display: "none",
+          name: 'admin',
+          header: 'General Admin & Finance',
+          content: this.$t(`departments.admin.longDescription.${this.$store.state.city}`),
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "city",
-          header: "General City Responsibilities",
-          content: "",
-          budget: "$x mil",
-          display: "none",
+          name: 'city',
+          header: 'General City Responsibilities',
+          content: this.$t(`departments.city.longDescription.${this.$store.state.city}`),
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "welfare",
-          header: "Human Welfare & Neighborhood Development",
-          content: "",
-          budget: "$x mil",
-          display: "none",
+          name: 'welfare',
+          header: 'Human Welfare & Neighborhood Development',
+          content: this.$t(`departments.welfare.longDescription.${this.$store.state.city}`),
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "protection",
-          header: "Public Protection",
-          content: "",
-          budget: "$x mil",
-          display: "none",
+          name: 'protection',
+          header: 'Public Protection',
+          content: this.$t(`departments.protection.longDescription.${this.$store.state.city}`),
+          budget: '$x mil',
+          display: 'none',
         },
         {
-          name: "transport",
-          header: "Public Works, Transportation, & Commerce",
-          content: "",
-          budget: "$x mil",
-          display: "none",
+          name: 'transport',
+          header: 'Public Works, Transportation, & Commerce',
+          content: this.$t(`departments.transport.longDescription.${this.$store.state.city}`),
+          budget: '$x mil',
+          display: 'none',
         },
       ],
       buttons: [
         {
-          name: "prev",
+          name: 'prev',
           outlined: true,
-          method: "previous",
-          class: "",
+          method: 'previous',
+          class: '',
           render: false,
         },
         {
-          name: "next",
+          name: 'next',
           outlined: false,
-          method: "next",
-          class: "white--text",
+          method: 'next',
+          class: 'white--text',
           render: true,
         },
         {
-          name: "finish",
+          name: 'finish',
           outlined: false,
-          method: "next",
-          class: "white--text",
+          method: 'next',
+          class: 'white--text',
           render: false,
         },
       ],
@@ -180,28 +177,28 @@ export default {
   },
   methods: {
     expand() {
-      const Text = document.querySelector(".Category-Content-Text");
-      Text.style.overflow = "inherit";
-      const Btn = document.getElementById("btn");
+      const Text = document.querySelector('.Category-Content-Text');
+      Text.style.overflow = 'inherit';
+      const Btn = document.getElementById('btn');
       Btn.remove();
     },
     navigate(button) {
       this.buttons[0].render = true;
-      if (button === "next") {
-        this.departments[this.index].display = "none";
+      if (button === 'next') {
+        this.departments[this.index].display = 'none';
         this.index += 1;
-        this.departments[this.index].display = "inherit";
-      } else if (button === "prev") {
-        this.departments[this.index].display = "none";
+        this.departments[this.index].display = 'inherit';
+      } else if (button === 'prev') {
+        this.departments[this.index].display = 'none';
         this.index -= 1;
-        this.departments[this.index].display = "inherit";
-      } else if (button === "finish") {
-        //change Balance-Budget-Show to display: flex
-        const budgetShow = document.getElementById("hide-for-walkthrough");
-        budgetShow.style.display = "block";
-        //change Category-Background to display: none
-        const walkthrough = document.querySelector(".Category-Background");
-        walkthrough.style.display = "none";
+        this.departments[this.index].display = 'inherit';
+      } else if (button === 'finish') {
+        // change Balance-Budget-Show to display: flex
+        const budgetShow = document.getElementById('hide-for-walkthrough');
+        budgetShow.style.display = 'block';
+        // change Category-Background to display: none
+        const walkthrough = document.querySelector('.Category-Background');
+        walkthrough.style.display = 'none';
       }
       if (this.index === 0) {
         this.buttons[0].render = false;
@@ -211,17 +208,17 @@ export default {
       }
     },
     updateAmount(department, value) {
-      this.$store.commit("budget/updateAmounts", { [department]: value });
+      this.$store.commit('budget/updateAmounts', { [department]: value });
     },
     showBudget() {
-      //change Balance-Budget-Show to display: flex
-      const budgetShowDivs = document.querySelectorAll(".hide-for-walkthrough");
-      budgetShowDivs.forEach(function (budgetShow) {
-        budgetShow.style.display = "flex";
+      // change Balance-Budget-Show to display: flex
+      const budgetShowDivs = document.querySelectorAll('.hide-for-walkthrough');
+      budgetShowDivs.forEach((budgetShow) => {
+        budgetShow.style.display = 'flex';
       });
-      //change Category-Background to display: none
-      const walkthrough = document.querySelector(".Category-Background");
-      walkthrough.style.display = "none";
+      // change Category-Background to display: none
+      const walkthrough = document.querySelector('.Category-Background');
+      walkthrough.style.display = 'none';
     },
   },
 };

--- a/translations/en-US.js
+++ b/translations/en-US.js
@@ -3,30 +3,51 @@ export default {
     health: {
       name: 'Community Health',
       description: 'Public health',
+      longDescription: {
+        san_francisco: 'The mission of the Department of Public Health is to protect and promote the health of all San Franciscans through the following divisions:<ul><li>San Francisco Health Network, which includes the Zuckerberg San Francisco General Hospital, Laguna Honda Hospital, ambulatory care, and transitions that oversee client flow throughout the system of care.</li><li>Population Health Division, which addresses public health concerns, including consumer safety, health promotion and disease prevention, and the monitoring of threats to the public’s health.</li></ul><br>Funds:<ul><li>Expand behavioral services for vulnerable residents, many of whom are experiencing homelessness</li><li>Provide department-wide workplace equity training and education</li><li>Implement a new electronic health record that supports clinical operations and revenue collections</li><li>Promote health education, physical activity, and healthy eating in communities with high rates of sugary drink consumption, diabetes, obesity, and heart disease</li><li>Increase staff at the hospitals and budget for other medical supplies including test kits for population health and prevention</li></ul>.',
+      },
     },
     culture: {
       name: 'Culture & Recreation',
       description: 'Parks, open spaces, libraries, and cultural facilities',
+      longDescription: {
+        san_francisco: 'San Francisco’s recreational, cultural, and educational resources drive our quality of life and underlie our shared experience as a city. Keeping these institutions in a state of good repair is a priority. Departments include:<ul><li>Academy of Sciences</li><li>Arts Commission</li><li>Asian Art Museum</li><li>Fine Arts Museum (de Young and Legion of Honor Museums)</li><li>Law Library</li><li>Public Library (Main Library at Civic Center and 27 branch libraries)</li><li>Recreation & Parks (200+ parks, playgrounds, and open spaces)</li><li>War Memorial (War Memorial Opera House, Veterans Building, Davies Symphony Hall, and adjacent grounds)</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Source: City of San Francisco Budget Book',
+      },
     },
     admin: {
       name: 'General Admin & Finance',
       description: 'City planning, retirement, elected officials, and more',
+      longDescription: {
+        san_francisco: 'A departmental designation for expenditures and revenues that are citywide in nature. Examples are voter mandated General Fund support for transit, libraries, and other baselines, the General Fund portion of retiree health premiums, nonprofit cost of doing business increases, required reserve deposits and debt service. Departments include:<ul><li>Assessor/Recorder</li><li>Board of Supervisors</li><li>City Attorney</li><li>City Planning</li><li>Civil Service Commission</li><li>Controller</li><li>Elections</li><li>Ethics Commission</li><li>General Services Agency - City Administrator (aka Administrative Services)</li><li>General Services Agency - Technology</li><li>Health Service System</li><li>Human Resources</li><li>Mayor</li><li>Medical Examiner (Program under General Services Agency - City Admin)</li><li>Real Estate (Program under General Services Agency - City Admin)</li><li>Retirement System</li><li>Treasurer/Tax Collector</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Funds:<ul><li>Modernize the city’s property assessment and tax systems</li><li>Pay salaries</li><li>Prepares for future elections and increased voter turnout by increasing temporary staffing and administering the vote-by-mail program</li></ul>',
+      },
     },
     city: {
       name: 'General City Responsibilities',
       description: 'General city and general fund unallocated',
+      longDescription: {
+        san_francisco: 'dd',
+      },
     },
     welfare: {
       name: 'Human Welfare & Neighborhood Development',
       description: 'Child support, housing support, schools, and human services',
+      longDescription: {
+        san_francisco: 'ee',
+      },
     },
     protection: {
       name: 'Public Protection',
       description: 'Probation, sheriff, police, and fire departments',
+      longDescription: {
+        san_francisco: 'ff',
+      },
     },
     transport: {
       name: 'Public Works, Transportation & Commerce',
       description: 'Airport, building inspection, public utilities, and transportation',
+      longDescription: {
+        san_francisco: 'gg',
+      },
     },
   },
 };


### PR DESCRIPTION
This commit enables us to easily enable oakland translations in the department
walkthrough by simply adding them to the `en-US.js` file.