### PR TITLE
feat: Adding full SF/Oakland budget descriptions

### DIFF
--- a/components/BudgetLandingBox.vue
+++ b/components/BudgetLandingBox.vue
@@ -30,25 +30,11 @@ export default Vue.extend({
   },
   methods: {
     showWalkthrough() {
-      // change floating-card-container to display: none
-      const budgetShowDivs = document.querySelectorAll('.hide-for-walkthrough');
-      budgetShowDivs.forEach((budgetShow) => {
-        budgetShow.style.display = 'none';
-      });
-      // change Category-Background to display: block
-      const walkthrough = document.querySelector('.Category-Background');
-      walkthrough.style.display = 'block';
+      this.$store.commit('departments/goToWalkthrough');
       this.onExit();
     },
     showBudget() {
-      // change floating-card-container to display: flex
-      const budgetShowDivs = document.querySelectorAll('.hide-for-walkthrough');
-      budgetShowDivs.forEach((budgetShow) => {
-        budgetShow.style.display = 'flex';
-      });
-      // change Category-Background to display: none
-      const walkthrough = document.querySelector('.Category-Background');
-      walkthrough.style.display = 'none';
+      this.$store.commit('departments/goToOverview');
       this.onExit();
     },
   },

--- a/components/DepartmentsWalkthrough.vue
+++ b/components/DepartmentsWalkthrough.vue
@@ -1,69 +1,63 @@
 <template>
-  <v-container class="Category-Background carousel-view" fluid>
-    <transition-group class="carousel" tag="div">
-      <div
-        v-for="(department, i) in departments"
-        v-bind:key="department.name"
-        v-bind:style="{ display: department.display }"
-        class="slide"
-      >
-        <v-row>
-          <v-col class="Category-Title"
-            >{{ i + 1 }}. {{ department.header }}</v-col
-          >
-        </v-row>
-        <v-row class="Category-Content">
-          <v-col cols="7">
-            <v-row class="Category-Content-Text text-sm-body-1">
-              <span v-html="department.content"></span>
-            </v-row>
-            <v-row justify="center">
-              <v-btn
-                id="btn"
-                elevation="0"
-                outlined
-                color="#BDBDBD"
-                @click="expand"
-                >SEE MORE v</v-btn
-              >
-            </v-row>
-          </v-col>
-          <v-col cols="1"></v-col>
-          <v-col>
-            <v-row>
-              <div class="Category-Slider">
-                <div class="Slider-Amount">
-                  ${{ amounts[department.name] }} mil
-                </div>
-                <v-row justify="center">
-                  <v-slider
-                    v-bind:max="totalAmount"
-                    :value="amounts[department.name]"
-                    @change="
-                      (value) => {
-                        updateAmount(department.name, value);
-                      }
-                    "
-                    min="0"
-                    vertical
-                    track-color="#B6DADA"
-                    color="#2A6465"
-                  />
-                </v-row>
-              </div>
-            </v-row>
-            <v-row class="Category-Budget-Caption text-sm-body-1"
-              >Last year’s budget: {{ department.budget }}</v-row
+  <v-container class="Category-Background carousel-view" v-if="!shouldShowOverview" fluid>
+    <div class="slide">
+      <v-row>
+        <v-col class="Category-Title">
+          {{ activeDepartment.number }}. {{ activeDepartment.header }}
+        </v-col>
+      </v-row>
+      <v-row class="Category-Content">
+        <v-col cols="7">
+          <v-row class="Category-Content-Text text-sm-body-1">
+            <span v-html="activeDepartment.content"></span>
+          </v-row>
+          <v-row justify="center">
+            <v-btn
+              id="btn"
+              elevation="0"
+              outlined
+              color="#BDBDBD"
+              @click="expand"
+              >SEE MORE v</v-btn
             >
-          </v-col>
-        </v-row>
+          </v-row>
+        </v-col>
+        <v-col cols="1"></v-col>
+        <v-col>
+          <v-row>
+            <div class="Category-Slider">
+              <div class="Slider-Amount">
+                ${{ amounts[activeDepartment.name] }} mil
+              </div>
+              <v-row justify="center">
+                <v-slider
+                  v-bind:max="totalAmount"
+                  :value="amounts[activeDepartment.name]"
+                  @change="
+                    (value) => {
+                      updateAmount(activeDepartment.name, value);
+                    }
+                  "
+                  min="0"
+                  vertical
+                  track-color="#B6DADA"
+                  color="#2A6465"
+                />
+              </v-row>
+            </div>
+          </v-row>
+          <v-row class="Category-Budget-Caption text-sm-body-1"
+            >Last year’s budget: {{ activeDepartment.budget }}</v-row
+          >
+        </v-col>
+      </v-row>
+      <v-row class="controls">
         <div class="carousel-controls">
           <v-btn
             v-for="button in buttonsShow"
             v-bind:key="button.name"
             class="carousel-controls__button"
             v-bind:class="button.class"
-            v-bind:disabled="amounts[department.name] == 0"
             v-bind:outlined="button.outlined"
             rounded
             depressed
@@ -73,8 +67,8 @@
             >{{ button.name }}</v-btn
           >
         </div>
-      </div>
-    </transition-group>
+      </v-row>
+    </div>
     <div class="skip">
       <v-btn text @click="showBudget" class="skip" color="#2a6465"
         >SKIP TO OVERVIEW</v-btn
@@ -88,6 +82,9 @@ import { mapState } from 'vuex';
 
 export default {
   computed: {
+    shouldShowOverview() {
+      return this.$store.getters['departments/shouldShowOverview'];
+    },
     totalAmount() {
       return this.$store.getters['budget/getTotalAmount'];
     },
@@ -103,6 +100,7 @@ export default {
     departments() {
       return [
         {
+          number: 1,
           name: 'health',
           header: 'Community Health',
           content: this.$t(`departments.health.longDescription.${this.selectedCity}`),
@@ -110,6 +108,7 @@ export default {
           display: 'inherit',
         },
         {
+          number: 2,
           name: 'culture',
           header: 'Culture & Recreation',
           content: this.$t(`departments.culture.longDescription.${this.selectedCity}`),
@@ -117,6 +116,7 @@ export default {
           display: 'none',
         },
         {
+          number: 3,
           name: 'admin',
           header: 'General Admin & Finance',
           content: this.$t(`departments.admin.longDescription.${this.selectedCity}`),
@@ -124,6 +124,7 @@ export default {
           display: 'none',
         },
         {
+          number: 4,
           name: 'city',
           header: 'General City Responsibilities',
           content: this.$t(`departments.city.longDescription.${this.selectedCity}`),
@@ -131,6 +132,7 @@ export default {
           display: 'none',
         },
         {
+          number: 5,
           name: 'welfare',
           header: 'Human Welfare & Neighborhood Development',
           content: this.$t(`departments.welfare.longDescription.${this.selectedCity}`),
@@ -138,6 +140,7 @@ export default {
           display: 'none',
         },
         {
+          number: 6,
           name: 'protection',
           header: 'Public Protection',
           content: this.$t(`departments.protection.longDescription.${this.selectedCity}`),
@@ -145,6 +148,7 @@ export default {
           display: 'none',
         },
         {
+          number: 7,
           name: 'transport',
           header: 'Public Works, Transportation, & Commerce',
           content: this.$t(`departments.transport.longDescription.${this.selectedCity}`),
@@ -152,6 +156,11 @@ export default {
           display: 'none',
         },
       ];
+    },
+    activeDepartment() {
+      return this.departments.find(
+        (dep) => dep.name === this.$store.getters['departments/getActiveDepartmentName'],
+      );
     },
   },
   data() {
@@ -161,21 +170,18 @@ export default {
         {
           name: 'prev',
           outlined: true,
-          method: 'previous',
           class: '',
           render: false,
         },
         {
           name: 'next',
           outlined: false,
-          method: 'next',
           class: 'white--text',
           render: true,
         },
         {
           name: 'finish',
           outlined: false,
-          method: 'next',
           class: 'white--text',
           render: false,
         },
@@ -192,24 +198,15 @@ export default {
     navigate(button) {
       this.buttons[0].render = true;
       if (button === 'next') {
-        this.departments[this.index].display = 'none';
-        this.index += 1;
-        this.departments[this.index].display = 'inherit';
+        this.$store.commit('departments/nextDepartment');
       } else if (button === 'prev') {
-        this.departments[this.index].display = 'none';
-        this.index -= 1;
-        this.departments[this.index].display = 'inherit';
+        this.$store.commit('departments/previousDepartment');
       } else if (button === 'finish') {
-        // change Balance-Budget-Show to display: flex
-        const budgetShow = document.getElementById('hide-for-walkthrough');
-        budgetShow.style.display = 'block';
-        // change Category-Background to display: none
-        const walkthrough = document.querySelector('.Category-Background');
-        walkthrough.style.display = 'none';
+        this.showBudget();
       }
-      if (this.index === 0) {
+      if (this.$store.getters['departments/getActiveDepartmentName'] === 'health') {
         this.buttons[0].render = false;
-      } else if (this.index === 6) {
+      } else if (this.$store.getters['departments/getActiveDepartmentName'] === 'transport') {
         this.buttons[1].render = false;
         this.buttons[2].render = true;
       }
@@ -218,14 +215,7 @@ export default {
       this.$store.commit('budget/updateAmounts', { [department]: value });
     },
     showBudget() {
-      // change Balance-Budget-Show to display: flex
-      const budgetShowDivs = document.querySelectorAll('.hide-for-walkthrough');
-      budgetShowDivs.forEach((budgetShow) => {
-        budgetShow.style.display = 'flex';
-      });
-      // change Category-Background to display: none
-      const walkthrough = document.querySelector('.Category-Background');
-      walkthrough.style.display = 'none';
+      this.$store.commit('departments/goToOverview');
     },
   },
 };
@@ -239,7 +229,6 @@ export default {
 .Category-Background {
   background: #f1f8f8;
   width: 1280px;
-  display: none;
 }
 .Category-Title {
   color: #000000;
@@ -284,18 +273,13 @@ export default {
   color: #4f4f4f;
   padding: 10px;
 }
-.carousel {
-  overflow: none;
-  background: #ffffff;
-}
 .slide {
-  height: 750px;
+  background: #ffffff;
   overflow: hidden;
 }
-.carousel-controls {
-  background: #ffffff;
+.controls {
+  justify-content: center;
   text-align: center;
-  z-index: 100;
   padding-bottom: 100px;
 }
 .skip {

--- a/pages/balance-budget.vue
+++ b/pages/balance-budget.vue
@@ -56,7 +56,7 @@
         </v-col>
       </v-row>
 
-      <v-row class="hide-for-walkthrough" justify="center">
+      <v-row v-if="showBudgetOverview" justify="center">
         <v-col class='slider col-12 col-sm-6 col-md-3'
                v-for="dept in budgetData" :key="dept.key">
           <v-spacer />
@@ -94,7 +94,7 @@
         </v-col>
       </v-row>
 
-      <v-row class="hide-for-walkthrough my-10" justify="center">
+      <v-row v-if="showBudgetOverview" class="my-10" justify="center">
         <v-spacer />
         <v-col cols="2"
           ><v-btn rounded color="#2A6465" dark block>NEXT</v-btn></v-col
@@ -102,7 +102,7 @@
         <v-spacer />
       </v-row>
 
-      <v-row class="hide-for-walkthrough my-10" justify="center">
+      <v-row v-if="showBudgetOverview" class="my-10" justify="center">
         <v-spacer />
       </v-row>
     </v-container>
@@ -146,6 +146,9 @@ export default Vue.extend({
     this.isMounted = true;
   },
   computed: {
+    showBudgetOverview() {
+      return this.$store.getters['departments/shouldShowOverview'];
+    },
     exceedsLimit() {
       return this.$store.getters['budget/getExceedsLimit'];
     },

--- a/store/departments.js
+++ b/store/departments.js
@@ -1,0 +1,48 @@
+const departments = [
+  'health',
+  'culture',
+  'admin',
+  'city',
+  'welfare',
+  'protection',
+  'transport',
+  'overview',
+];
+
+export const state = () => ({
+  active_department: 0,
+});
+
+export const getters = {
+  getActiveDepartment(st) {
+    return st.active_department;
+  },
+  getActiveDepartmentName(st) {
+    return departments[st.active_department];
+  },
+  shouldShowOverview(st) {
+    return st.active_department === 7;
+  },
+};
+
+export const mutations = {
+  nextDepartment(st) {
+    if (st.active_department < 6) {
+      st.active_department += 1;
+    }
+  },
+
+  previousDepartment(st) {
+    if (st.active_department >= 1) {
+      st.active_department -= 1;
+    }
+  },
+
+  goToWalkthrough(st) {
+    st.active_department = 0;
+  },
+
+  goToOverview(st) {
+    st.active_department = 7;
+  },
+};

--- a/translations/en-US.js
+++ b/translations/en-US.js
@@ -5,7 +5,7 @@ export default {
       description: 'Public health',
       longDescription: {
         san_francisco: 'The mission of the Department of Public Health is to protect and promote the health of all San Franciscans through the following divisions:<ul><li>San Francisco Health Network, which includes the Zuckerberg San Francisco General Hospital, Laguna Honda Hospital, ambulatory care, and transitions that oversee client flow throughout the system of care.</li><li>Population Health Division, which addresses public health concerns, including consumer safety, health promotion and disease prevention, and the monitoring of threats to the public’s health.</li></ul><br>Funds:<ul><li>Expand behavioral services for vulnerable residents, many of whom are experiencing homelessness</li><li>Provide department-wide workplace equity training and education</li><li>Implement a new electronic health record that supports clinical operations and revenue collections</li><li>Promote health education, physical activity, and healthy eating in communities with high rates of sugary drink consumption, diabetes, obesity, and heart disease</li><li>Increase staff at the hospitals and budget for other medical supplies including test kits for population health and prevention</li></ul>.',
-        oakland: 'Oakland version of community health',
+        oakland: 'The City of Oakland does not maintain a Public Health budget. All funding for Oakland Public Health comes from the Alameda County budget.  The Alameda County budget does not show specifically how much is allocated to the City of Oakland; Oakland comprises 25 - 30% of the County’s population.',
       },
     },
     culture: {
@@ -13,7 +13,7 @@ export default {
       description: 'Parks, open spaces, libraries, and cultural facilities',
       longDescription: {
         san_francisco: 'San Francisco’s recreational, cultural, and educational resources drive our quality of life and underlie our shared experience as a city. Keeping these institutions in a state of good repair is a priority. Departments include:<ul><li>Academy of Sciences</li><li>Arts Commission</li><li>Asian Art Museum</li><li>Fine Arts Museum (de Young and Legion of Honor Museums)</li><li>Law Library</li><li>Public Library (Main Library at Civic Center and 27 branch libraries)</li><li>Recreation & Parks (200+ parks, playgrounds, and open spaces)</li><li>War Memorial (War Memorial Opera House, Veterans Building, Davies Symphony Hall, and adjacent grounds)</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Source: City of San Francisco Budget Book',
-        oakland: 'Oakland version of culture & rec',
+        oakland: 'Oakland’s parks and libraries provide facilities and programs to enable citizens to learn, explore and connect; to provide clean, healthy recreational facilities, both citywide and in local neighborhoods<br><br>Departments:<ul><li>Oakland Public Library</li><li>Oakland Parks, Recreation & Youth Development</li></ul>',
       },
     },
     admin: {
@@ -21,39 +21,39 @@ export default {
       description: 'City planning, retirement, elected officials, and more',
       longDescription: {
         san_francisco: 'A departmental designation for expenditures and revenues that are citywide in nature. Examples are voter mandated General Fund support for transit, libraries, and other baselines, the General Fund portion of retiree health premiums, nonprofit cost of doing business increases, required reserve deposits and debt service. Departments include:<ul><li>Assessor/Recorder</li><li>Board of Supervisors</li><li>City Attorney</li><li>City Planning</li><li>Civil Service Commission</li><li>Controller</li><li>Elections</li><li>Ethics Commission</li><li>General Services Agency - City Administrator (aka Administrative Services)</li><li>General Services Agency - Technology</li><li>Health Service System</li><li>Human Resources</li><li>Mayor</li><li>Medical Examiner (Program under General Services Agency - City Admin)</li><li>Real Estate (Program under General Services Agency - City Admin)</li><li>Retirement System</li><li>Treasurer/Tax Collector</li></ul><br>Funds:<ul><li>Subsidize museum free days and the free admission program for San Francisco school groups.</li><li>Provide arts education, arts organizations, affordable space, and support for individual artists</li><li>Maintain buildings and modernize collections management</li><li>Sponsor special exhibitions that educate and stimulate curiosity among broad and diverse audiences</li><li>Increase open hours at public libraries, eliminate overdue fines, increase eCollections circulation</li><li>Maintains all public parks and provides a broad range of recreation programming in community services, cultural arts, sports and athletics, and leisure services</li></ul><br>Funds:<ul><li>Modernize the city’s property assessment and tax systems</li><li>Pay salaries</li><li>Prepares for future elections and increased voter turnout by increasing temporary staffing and administering the vote-by-mail program</li></ul>',
-        oakland: 'Oakland version of admin & finance',
+        oakland: 'A departmental designation for expenditures and revenues that are citywide in nature. The functions of these departments include: adopting an annual budget for the city; administering its programs; providing legal support for enforcing the City’s ordinances; monitoring compliance with the City’s programs.<br><br>Departments:<ul><li>Mayor</li><li>City Council</li><li>City Administrator</li><li>City Attorney</li><li>City Auditor</li><li>City Clerk</li><li>Public Ethics Commission </li><li>Finance Dept.</li><li>Information Technology Dept.</li><li>Human Resources</li></ul>',
       },
     },
     city: {
       name: 'General City Responsibilities',
       description: 'General city and general fund unallocated',
       longDescription: {
-        san_francisco: 'dd',
-        oakland: 'Oakland version of city',
+        san_francisco: 'General city responsibilities refers to city administrative and oversight responsibilities that do not fall into other categories.<br><br>Departments:<ul><li>City Administrator</li><li>Commercial Investment/Infrastructure</li><li>County Education</li><li>General City Responsibility</li><li>Superior Court</li></ul>',
+        oakland: 'General city responsibilities refers to city administrative and oversight responsibilities that do not fall into other categories.<br><br>Departments:<ul><li>Citywide Activities</li><li>Debt/Lease Payments</li><li>Fiscal Management</li><li>Insurance & Liability Claims</li></ul>',
       },
     },
     welfare: {
       name: 'Human Welfare & Neighborhood Development',
       description: 'Child support, housing support, schools, and human services',
       longDescription: {
-        san_francisco: 'ee',
-        oakland: 'Oakland version of welfare & development',
+        san_francisco: 'These departments provide decent and affordable housing, and enrich the quality of life, for all of the City’s residents.<br><br>Departments:<ul><li>Child Support Services</li><li>Children & Families Comm.</li><li>Children; Youth & Their Families</li><li>Environment</li><li>Homelessness & Supp Housing</li><li>Human Rights Commission</li><li>Human Services</li><li>Rent Arbitration Board</li><li>Status of Women</li></ul>',
+        oakland: 'Departments that provide decent and affordable housing, and enrich the quality of life, for all of the City’s residents.<br><br>Departments:<ul><li>Housing & Community Development</li><li>Human Services</li></ul>',
       },
     },
     protection: {
       name: 'Public Protection',
       description: 'Probation, sheriff, police, and fire departments',
       longDescription: {
-        san_francisco: 'ff',
-        oakland: 'Oakland version of public protection',
+        san_francisco: 'City responsibilities that cover the maintenance of public safety, including both responses to crime and responses to natural disasters.<br><br>Departments:<ul><li>Adult Probation</li><li>District Attorney</li><li>Emergency Management</li><li>Fire Dept.</li><li>Juvenile Probation</li><li><b>Police</b></li><li><b>Police Accountability</b></li><li><b>Public Defender</b></li><li><b>Sheriff</b></li></ul><br><br>Funds:<ul><li>Pay for supervision and therapeutic services of high risk individuals in Adult Probation Department</li><li>Pay for salary and benefit increases in district attorney’s office, fire department</li><li>Increase fully-trained staff to meet demand for increasing 911 emergency call volumes</li><li>Upgrade Public Safety Radio System and Computer Aided Dispatch System technologies</li><li>Upgrade tools, equipment, and vehicles for fire department</li><li>Hire 250 additional police officers and 50 civilian staff deployed to address car-break-ins, property crimes, street conditions, and traffic law violations.</li><li>Upgrade 10% of fleet of marked police vehicles</li><li>Comply with new transparency lawas to digitize documentation and storage of full investigation files and full-body worn camera footage</li></ul>',
+        oakland: 'City responsibilities that cover the maintenance of public safety, including both responses to crime and responses to natural disasters.<br><br>Departments:<ul><li>Police Commision</li><li>Police Department</li><li>Race & Equity</li><li>Dept. of Violence Prevention</li><li>Fire Dept</li></ul>',
       },
     },
     transport: {
       name: 'Public Works, Transportation & Commerce',
       description: 'Airport, building inspection, public utilities, and transportation',
       longDescription: {
-        san_francisco: 'gg',
-        oakland: 'Oakland version of public works',
+        san_francisco: 'This category includes departments relating to the management of a city’s infrastructure. This covers transportation, utilities, construction, and other economic concerns.<br><br>Departments:<ul><li>Airport Commission</li><li>Board of Appeals</li><li>Building Inspection</li><li>Economic & Workforce Development</li><li>Municipal Transportation Agency</li><li>Port</li><li>Public Utilities Commission</li></ul>',
+        oakland: 'These departments foster the City’s economic growth; develop safe and healthy communities; maintain and improve the infrastructure; provide safe, reliable public transportation.<br><br>Departments:<ul><li>Workplace and Employment Standards</li><li>Economic & Workforce Development</li><li>Planning & Building</li><li>Public Works</li><li>Transportation</li><li>Capital Improvement Program</li></ul>',
       },
     },
   },


### PR DESCRIPTION
This change also refactors how we handle the department screens in
the walkthough, moving this state to the global store. This allows
us to better mutate and read it from the various components, thereby
cleaning up some of the code and relying on Vue's directives rather
than switching display styles.
