### PR TITLE
feat: Add overview with overlay page

### DIFF
--- a/components/DepartmentsWalkthrough.vue
+++ b/components/DepartmentsWalkthrough.vue
@@ -1,5 +1,7 @@
 <template>
-  <v-container class="Category-Background carousel-view" v-if="!shouldShowOverview" fluid>
+  <v-container class="Category-Background carousel-view"
+               v-if="!shouldShowOverview && !shouldShowOverviewWithOverlay"
+               fluid>
     <div class="slide">
       <v-row>
         <v-col class="Category-Title">
@@ -78,19 +80,16 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 
 export default {
   computed: {
-    shouldShowOverview() {
-      return this.$store.getters['departments/shouldShowOverview'];
-    },
-    totalAmount() {
-      return this.$store.getters['budget/getTotalAmount'];
-    },
-    amounts() {
-      return this.$store.getters['budget/getAmounts'];
-    },
+    ...mapGetters({
+      shouldShowOverview: 'departments/shouldShowOverview',
+      shouldShowOverviewWithOverlay: 'departments/shouldShowOverviewWithOverlay',
+      totalAmount: 'budget/getTotalAmount',
+      amounts: 'budget/getAmounts',
+    }),
     buttonsShow() {
       return this.buttons.filter((button) => button.render);
     },

--- a/store/budget.js
+++ b/store/budget.js
@@ -33,8 +33,14 @@ export const getters = {
   getRealAmounts(st) {
     return st.real_amounts;
   },
+  getAllAmounts(st) {
+    return Object.entries(st.amounts).reduce((hash, [key, value]) => {
+      hash[key] = [value, st.real_amounts[key]];
+      return hash;
+    }, {});
+  },
   getRemainingAmount(st) {
-    return st.total_amount - Object.values(st.amounts).reduce((a, b) => a + b);
+    return st.total_amount - Object.values(st.amounts).reduce((a, b) => a + b, 0);
   },
   getExceedsLimit(st) {
     return Object.values(st.amounts)

--- a/store/departments.js
+++ b/store/departments.js
@@ -7,6 +7,7 @@ const departments = [
   'protection',
   'transport',
   'overview',
+  'overviewWithOverlay',
 ];
 
 export const state = () => ({
@@ -22,6 +23,9 @@ export const getters = {
   },
   shouldShowOverview(st) {
     return st.active_department === 7;
+  },
+  shouldShowOverviewWithOverlay(st) {
+    return st.active_department === 8;
   },
 };
 
@@ -44,5 +48,9 @@ export const mutations = {
 
   goToOverview(st) {
     st.active_department = 7;
+  },
+
+  goToOverviewWithOverlay(st) {
+    st.active_department = 8;
   },
 };


### PR DESCRIPTION


Adds overlapping sliders from the real amounts in orange, with
    custom CSS to handle the overlapping elements. Also makes the
    slider hint use visibility so as to take up space in the DOM
    even when hidden.

<img width="1560" alt="Screen Shot 2020-11-18 at 10 06 51 PM" src="https://user-images.githubusercontent.com/12961270/99628399-eec66e80-29ea-11eb-9f2b-feb383cacb65.png">