### PR TITLE
feat: Add overview with overlay page

### DIFF
--- a/components/DepartmentsWalkthrough.vue
+++ b/components/DepartmentsWalkthrough.vue
@@ -221,7 +221,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 @font-face {
   font-family: "Avenir";
   src: url("../assets/AvenirLTStd-Medium.otf");

--- a/store/budget.js
+++ b/store/budget.js
@@ -60,4 +60,11 @@ export const mutations = {
   updateRealAmounts(st, amountUpdates) {
     st.real_amounts = { ...st.real_amounts, ...amountUpdates };
   },
+
+  resetAmounts(st) {
+    st.amounts = Object.keys(st.amounts).reduce((hash, key) => {
+      hash[key] = 0;
+      return hash;
+    }, {});
+  },
 };


### PR DESCRIPTION
Adds overlapping sliders from the real amounts in orange, with
custom CSS to handle the overlapping elements. Also makes the
slider hint use visibility so as to take up space in the DOM
even when hidden.
![Screen Shot 2020-12-02 at 17 46 41-fullpage](https://user-images.githubusercontent.com/12961270/100952967-6229af00-34c6-11eb-970f-996de73bc3ab.png)